### PR TITLE
feat: guessing mandatory fields

### DIFF
--- a/pkg/tracking/jira/client.go
+++ b/pkg/tracking/jira/client.go
@@ -71,7 +71,7 @@ func contains(elems []string, v string) bool {
 }
 
 // CreateTicket creates a ticket in Jira.
-func (cl *Client) CreateTicket(ticket *model.Ticket) (*model.Ticket, error) {
+func (cl *Client) CreateTicket(ticket *model.Ticket, issueType string) (*model.Ticket, error) {
 
 	queryOptions := &gojira.GetQueryOptions{
 		ProjectKeys: ticket.Project,
@@ -133,7 +133,7 @@ func (cl *Client) CreateTicket(ticket *model.Ticket) (*model.Ticket, error) {
 			Description: ticket.Description,
 			Summary:     ticket.Summary,
 			Type: gojira.IssueType{
-				Name: ticket.TicketType,
+				Name: issueType,
 			},
 			Project: gojira.Project{
 				Key: ticket.Project,


### PR DESCRIPTION
IMPORTANT!! This PR is not meant to be merged now.

As this repo is private, is not possible to create a PR as a draft.

This development was done when we were exploring the possibility to adapt vulcan-tracker to any Jira project without knowing the fields (mandatory or not) required to create an issue.

To avoid errors when creating an issue, the idea was to try to guess the mandatory fields without a default value and choose the first value available.

