### PR TITLE
feat: add labels to the ticket creation

### DIFF
--- a/docs/api.json
+++ b/docs/api.json
@@ -244,6 +244,13 @@
           "ticket_type": {
             "type": "string",
             "description": "Issue type of the ticket"
+          },
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Jira labels"
+            }
           }
         }
       },
@@ -327,7 +334,10 @@
           "summary": "Outdated Packages in Docker Image",
           "description": "Long text with a detailed description of the ticket.",
           "project": "PTVUL",
-          "ticket_type": "Vulnerability"
+          "ticket_type": "Vulnerability",
+          "labels": [
+            "potential"
+          ]
         }
       },
       "ticketResponseExample": {

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -157,6 +157,11 @@ components:
         ticket_type:
           type: string
           description: Issue type of the ticket
+        labels:
+          type: array
+          items:
+            type: string
+            description: Jira labels
     ticketResponse:
       allOf:
         - type: object
@@ -190,9 +195,7 @@ components:
       properties:
         id:
           type: string
-          description: >-
-            Identification of the relationship between a finding and a ticket
-            for a team in uuid format
+          description: Identification of the relationship between a finding and a ticket for a team in uuid format
         finding_id:
           type: string
           description: Finding identification in uuid format
@@ -215,6 +218,8 @@ components:
         description: Long text with a detailed description of the ticket.
         project: PTVUL
         ticket_type: Vulnerability
+        labels:
+          - potential
     ticketResponseExample:
       value:
         id: 875abf8c-f9a2-473a-8623-5a85c85a3af9

--- a/pkg/api/tracking_test.go
+++ b/pkg/api/tracking_test.go
@@ -405,7 +405,7 @@ func TestCreateTicket(t *testing.T) {
 			}
 
 			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(qsStrData))
-			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			rec := httptest.NewRecorder()
 
 			c := e.NewContext(req, rec)


### PR DESCRIPTION
The tracker already had the functionality implemented but the labels were missing in the swagger documentation.